### PR TITLE
add ansible-galaxy metadata

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,17 @@
+---
+dependencies: []
+
+galaxy_info:
+  role_name: network
+  author: Michael Aldridge
+  description: Manage various network components, using dhcpcd and iptables.
+  license: license (MIT)
+  platforms:
+    - name: Void Linux
+      version:
+        - all
+  galaxy_tags:
+    - networking
+    - system
+    - firewall
+    - security


### PR DESCRIPTION
Let me know how this looks.

FYI I was looking around and it looks like the namespace is really tied to github accounts, so it looks like no matter what the `author:` field says, you could upload it with void-ansible-roles org, or a different account and have the namespace of the submitter?

I started with this because almost every other role depends on it, and I want to then figure out how the dependencies actually work, e.g. if you can keep them named the same and pull from anisble-galaxy namespaces and match, or if you need to declare them specifically as ansible galaxy in metadata. The documentation is not very great tbh.