### PR TITLE
ifupdown: switch static and stateless configuration to ifupdown

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,6 +37,29 @@
     group: root
     mode: 0755
 
+- name: Install ifupdown
+  xbps:
+    pkg: ifupdown
+    state: present
+
+- name: Configure ifupdown
+  template:
+    src: interfaces.j2
+    dest: /etc/network/interfaces
+    owner: root
+    group: root
+    mode: 0644
+  vars:
+    network_netmask: "{{ ansible_default_ipv4.address }}/{{ ansible_default_ipv4.netmask }}"
+    network_cidr: "{{ ansible_default_ipv4.address }}/{{ network_netmask | ipaddr('prefix') }}"
+
+- name: Set SLAAC method
+  sysctl:
+    name: net.ipv6.conf.default.addr_gen_mode
+    sysctl_set: yes
+    reload: yes
+    value: '{{ 0 if network_address_slaac_mode == "hwaddr" else 2 }}'
+
 - name: Configure dhcpcd
   template:
     src: dhcpcd.conf.j2
@@ -45,8 +68,6 @@
     group: root
     mode: 0644
   vars:
-    network_netmask: "{{ ansible_default_ipv4.address }}/{{ ansible_default_ipv4.netmask }}"
-    network_cidr: "{{ ansible_default_ipv4.address }}/{{ network_netmask | ipaddr('prefix') }}"
     dhcp_interfaces: "{{ network_interfaces | json_query('[*].mode') }}"
   notify:
     - dhcpcd

--- a/templates/dhcpcd.conf.j2
+++ b/templates/dhcpcd.conf.j2
@@ -1,17 +1,12 @@
 controlgroup wheel
 persistent
-{% if 'dhcp' in dhcp_interfaces %}
+{% if 'dhcp' in dhcp_interfaces|default({}) %}
 hostname
 duid
 {% for option in network_dhcp_options %}
 option {{ option }}
 {% endfor %}
 require dhcp_server_identifier
-{% endif %}
-{% if network_address_use_slaac %}
-slaac {{ network_address_slaac_mode }}
-{% endif %}
-
 
 {% for interface in network_interfaces %}
 {% if interface.name == 'default' %}
@@ -19,39 +14,17 @@ interface {{ ansible_default_ipv4.interface }}
 {% else %}
 interface {{ interface.name }}
 {% endif %}
-{% if interface.mode == 'static' %}
-	nodhcp
-{% if interface.addresses is defined %}
-{% for address in interface.addresses %}
-	static ip_address={{ address | default(network_cidr) }}
-{% endfor %}
-{% else %}
-	static ip_address={{ network_cidr }}
-{% endif %}
-{% for router in interface.routers %}
-	static routers={{ router | default(ansible_default_ipv4.gateway) }}
-{% endfor %}
-{% elif interface.mode == 'dhcp' %}
+{% if interface.mode == 'dhcp' %}
 	dhcp
-{% elif interface.mode == 'disabled' %}
+{% else %}
 	noipv4
 {% endif %}
-
-{% if interface.mode6 == 'static' %}
-{% if interface.routers6 | default(false) %}
-	noipv6rs
-{% endif %}
-{% for address6 in interface.addresses6 %}
-	static ip6_address={{ address6 }}
-{% endfor %}
-{% if interface.routers6 is defined %}
-{% for router6 in interface.routers6 %}
-	static routers={{ router6 | default(ansible_default_ipv6.gateway) }}
-{% endfor %}
-{% endif %}
-{% elif interface.mode6 == 'dhcp' %}
+{% if interface.mode6 == 'dhcp' %}
 	dhcp6
-{% elif interface.mode6 == 'disabled' %}
+{% else %}
 	noipv6
 {% endif %}
 {% endfor %}
+{% else %}
+nogateway
+{% endif %}

--- a/templates/interfaces.j2
+++ b/templates/interfaces.j2
@@ -1,0 +1,40 @@
+# this file is managed by ansible, local changes will not persist
+
+source /etc/network/interfaces.d/*
+
+{# special-case loopback -#}
+auto lo
+iface lo inet loopback
+
+{% for interface in network_interfaces -%}
+{% set mode = interface.mode | default("disabled") -%}
+{% set mode6 = interface.mode6 | default("disabled") -%}
+
+{% if interface.name in ansible_facts.interfaces and (mode != "disabled" or mode6 != "disabled") -%}
+auto {{ interface.name }}
+{% if mode != "disabled" -%}
+iface {{ interface.name }} inet {{ mode }}
+{% if mode == "static" -%}
+{# ansible-based autodetection IS NOT SUPPORTED in the refactor -#}
+{%- for address in interface.addresses %}
+    address {{ address }}
+{% endfor %}
+{%- for gateway in interface.routers %}
+    gateway {{ gateway }}
+{% endfor %}
+{% endif %}
+{% endif %}
+{# second verse, same as the first, little bit louder, little bit ipv6 -#}
+{% if mode6 != "disabled" -%}
+iface {{ interface.name }} inet6 {{ mode6 }}
+{% if mode6 == "static" %}
+{%- for address in interface.addresses6 %}
+    address {{ address }}
+{% endfor %}
+{%- for gateway in interface.routers6 | default(["fe80::1"]) %}
+    gateway {{ gateway }}
+{% endfor %}
+{% endif %}
+{% endif %}
+{% endif %}
+{% endfor %}


### PR DESCRIPTION
While not nearly as exciting, ifupdown provides a significantly cleaner
interface for static network configuratons. On Void it has the
additional benefit of being run as part of stage 1 which guarantees a
static network before the supervisor starts bringing up other services
which should have additional benefits around service reliability. I
tried to make things as straight forward an unsurprising as possible so
many of the ansible_default_* calls have been removed. This means that
host layouts like b-hel-fi will most likely be incorrect until a
network_interfaces block can be written but there should be less
reliance on prior state to correctly configure a system.

If races still exist on the DO hosts between dhcp resolution and network
clients there are a couple of ways to solve that. The simplest is to add
some variety of DNS call to short-circuit the dependent run scripts
though if that isn't good enough I have an entirely experimental branch
that emulates service readiness with dhcpcd and runit.

Caveats:
This commit does not entirely shut off dhcpcd for fully static builds
however. The current builds rely on dhcpcd to handle merging the
configuration and it was easier to borrow that behavior for the time
being. Also, I didn't have access to running configs and my VM test
system needs some love so I wasn't able to end-to-end satisfactorily
test every configuration (notably the pure DHCP and SLAAC setups). I'm
pretty sure it covers all of the main cases but I wouldn't be surprised
if bugs are hiding out somewhere.